### PR TITLE
Android Build image upgrades

### DIFF
--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -40,7 +40,6 @@ ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_
 
 # --- Update the android SDK repositories ---
 RUN echo y | android update sdk --no-ui --all --filter platform-tools | grep 'package installed'
-RUN echo y | android update sdk --no-ui --all --filter extra-android-support | grep 'package installed'
 
 # --- Install android SDK
 # * If you are installing multiple SDK packages keep these in descending order!

--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -60,6 +60,7 @@ RUN echo y | android update sdk --no-ui --all --filter addon-google_apis-google-
 
 # --- Install Gradle ---
 RUN apt-get -y install gradle
+RUN mkdir ~/.gradle && touch ~/.gradle/gradle.properties
 RUN gradle -v
 
 # --- Install Maven 3 ---

--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -72,7 +72,18 @@ RUN mvn --version
 # --- Install NodeJS required for react native projects
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get -y install nodejs
+
+# --- Install Yarn as an alternative to NPM for package management ---
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install yarn
+RUN yarn --version
+
+# --- Install React-Native's CLI ---
 RUN npm install -g react-native-cli
+
+# --- Install Microsoft's CodePush service ---
+RUN npm install -g code-push-cli
 
 # --- Cleanup ---
 RUN apt-get clean


### PR DESCRIPTION
The following upgrades were made:

1. Removed the extra-android-support library dependency as it is no longer used by the official Android SDK package. If needed these packages can be installed separately (needs testing on projects if anyone is using these.
2. Added Yarn package as an alternative to npm - I have made the very concious effort to move us towards Yarn and away from npm to ease our dependency hell. Yarn will now be available in our React-Native projects after this update.
3. Microsoft CodePush integration - Continuous Delivery is critical for my team for early prototyping and fast iteration cycle planning. This will now enable us to push code directly from the CI to the live apps on React Native. Very helpful if you don't want to wait for an Apple review or need to do some A/B testing to make some decisions.