### PR TITLE
Upgrading the Android build image to include later SDKs

### DIFF
--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -51,7 +51,7 @@ RUN echo y | android update sdk --no-ui --all --filter android-23 | grep 'packag
 # * If you are installing multiple build tool packages keep these in descending order!
 RUN echo y | android update sdk --no-ui --all --filter build-tools-25.0.2 | grep 'package installed'
 RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.3 | grep 'package installed'
-RUN echo y | android update sdk --no-ui --all --filter build-tools-23.0.3 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter build-tools-23.0.1 | grep 'package installed'
 
 # --- Install Extras
 RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository | grep 'package installed'

--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -49,7 +49,9 @@ RUN echo y | android update sdk --no-ui --all --filter android-23 | grep 'packag
 
 # --- Install build-tools
 # * If you are installing multiple build tool packages keep these in descending order!
-RUN echo y | android update sdk --no-ui --all --filter build-tools-23.0.1 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter build-tools-25.0.2 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.3 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter build-tools-23.0.3 | grep 'package installed'
 
 # --- Install Extras
 RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository | grep 'package installed'

--- a/android-build/Dockerfile
+++ b/android-build/Dockerfile
@@ -43,6 +43,8 @@ RUN echo y | android update sdk --no-ui --all --filter platform-tools | grep 'pa
 
 # --- Install android SDK
 # * If you are installing multiple SDK packages keep these in descending order!
+RUN echo y | android update sdk --no-ui --all --filter android-25 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter android-24 | grep 'package installed'
 RUN echo y | android update sdk --no-ui --all --filter android-23 | grep 'package installed'
 
 # --- Install build-tools


### PR DESCRIPTION
Since we have started using Lottie internally to do animations, our CI agents are failing, because Lottie requires Android SDK and build-tools 25.

This PR adds them to the main image, completely backwards compatible.