### PR TITLE
Updates to the Android build images.

### DIFF
--- a/android-build/LICENSE
+++ b/android-build/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Dubit Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/android-build/sdk-23/Dockerfile
+++ b/android-build/sdk-23/Dockerfile
@@ -36,8 +36,7 @@ ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}
 
 # --- Accept all standard component licenses before installing any component. ---
 # * Non-standard components: MIPS system images, preview versions, GDK (Google Glass) and Android Google TV require separate licenses, not accepted there
-RUN mkdir -p ${ANDROID_HOME}/licenses
-RUN echo 8933bad161af4178b1185d1a37fbf41ea5269c55 > ${ANDROID_HOME}/licenses/android-sdk-license
+RUN yes | sdkmanager --licenses
 
 # --- Update the android SDK repositories ---
 RUN sdkmanager "platform-tools"

--- a/android-build/sdk-25/Dockerfile
+++ b/android-build/sdk-25/Dockerfile
@@ -36,8 +36,7 @@ ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}
 
 # --- Accept all standard component licenses before installing any component. ---
 # * Non-standard components: MIPS system images, preview versions, GDK (Google Glass) and Android Google TV require separate licenses, not accepted there
-RUN mkdir -p ${ANDROID_HOME}/licenses
-RUN echo 8933bad161af4178b1185d1a37fbf41ea5269c55 > ${ANDROID_HOME}/licenses/android-sdk-license
+RUN yes | sdkmanager --licenses
 
 # --- Update the android SDK repositories ---
 RUN sdkmanager "platform-tools"
@@ -50,6 +49,7 @@ RUN sdkmanager "platforms;android-23"
 
 # --- Install build-tools
 # * If you are installing multiple build tool packages keep these in descending order!
+RUN sdkmanager "build-tools;25.0.3"
 RUN sdkmanager "build-tools;25.0.2"
 RUN sdkmanager "build-tools;24.0.3"
 RUN sdkmanager "build-tools;23.0.1"


### PR DESCRIPTION
- Added a LICENSE file.
- Additional build tools installed on the level 25 SDK image, because it's commonly required by React Native components.