### PR TITLE
Splitting the base Android image into a separate target. Adding a SDK-27 target.

### DIFF
--- a/android-build/README.md
+++ b/android-build/README.md
@@ -2,6 +2,7 @@
 ### `dubit/android-build-image`
 
 This image contains an environment that allows building Android applications within a containerized environment. It is roughly based on the [Bitrise.io Android image](https://github.com/bitrise-docker/android).
+All build images extend the `:base` build image. It contains all common utilities across the different SDK targets.
 
 ## Tools, compilers and utilities inside:
 * Base OS: Ubuntu:16.04
@@ -18,16 +19,17 @@ This image contains an environment that allows building Android applications wit
   * GCC (included by build-essential)
   * python 2.7
   * openJDK-8
-  * Node.js 6.x
+  * Node.js 9.x
+  * Ruby 2.3
 * SDKs:
-  * Android SDK 23
+  * Android SDK 23/25/27
   * Android NDK r10e
-  * Android build-tools 23.0.1
+  * Android build-tools - _all versions of build tools corresponding to the SDK version are included_
 
 ## How to use the image
 
 The image has an entrypoint inherited from Ubuntu's image which is **"/bin/bash"**. You can execute your build from within the container in the following way:
-> `docker run --rm=true -v <path/to/your/source>:/usr/src/app dubit/android-build-image /bin/bash -c "<comma separated list of commands that will build your app>"`
+> `docker run --rm=true -v <path/to/your/source>:/usr/src/app dubit/android-build-image:<sdk-version> /bin/bash -c "<comma separated list of commands that will build your app>"`
 
 The working directory is set to be the source of your application.
 

--- a/android-build/base/Dockerfile
+++ b/android-build/base/Dockerfile
@@ -1,0 +1,62 @@
+FROM ubuntu:16.04
+
+# --- Environment variables ---
+ENV ANDROID_HOME /opt/android-sdk-linux
+
+# --- Run system tool updates ---
+RUN apt-get update
+RUN apt-get -y install unzip curl git python build-essential
+
+# --- Install Android build requirements ---
+RUN dpkg --add-architecture i386
+RUN apt-get update -qq
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386
+
+# --- Install Gradle ---
+RUN apt-get -y install gradle
+
+# --- Install Maven 3 ---
+# * Purge any installations of Maven 1 & 2 including user configurations
+RUN apt-get purge maven maven2
+RUN apt-get -y install maven
+
+# --- Install Ruby required for Fastlane operations ---
+RUN apt-get -y install ruby-full
+RUN ruby -v
+
+# --- Install Bundler as the primary package manager for Ruby ---
+RUN gem install bundler
+
+# --- Install NodeJS required for react native projects
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
+RUN apt-get -y install nodejs
+
+# --- Install Yarn as an alternative to NPM for package management ---
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install yarn
+
+# --- Install React-Native's CLI ---
+RUN npm install -g react-native-cli
+
+# --- Create the Android repository config file ---
+# * This is not required, but makes warnings on installing packages go away.
+RUN mkdir /root/.android
+RUN touch /root/.android/repositories.cfg
+
+# --- Download the Android SDK tools and export to $ANDROID_HOME ---
+ENV ANDROID_HOME /opt/android-sdk-linux
+RUN cd /opt \
+  && curl https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -o android-sdk-tools.zip \
+  && unzip -q android-sdk-tools.zip -d ${ANDROID_HOME} \
+  && rm -f android-sdk-tools.zip
+
+# --- Update the PATH variable ---
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+
+# --- Accept all standard component licenses before installing any component. ---
+# * Non-standard components: MIPS system images, preview versions, GDK (Google Glass) and Android Google TV require separate licenses, not accepted there
+RUN yes | sdkmanager --licenses
+
+# --- Cleanup ---
+RUN apt-get clean

--- a/android-build/build.sh
+++ b/android-build/build.sh
@@ -3,18 +3,26 @@
 CURRENT_DIR=$(pwd)
 DIRECTORY_SEPARATOR="/"
 
-base_images=(sdk-23 sdk-25)
-ndk_images=(sdk-23-ndk sdk-25-ndk)
+base_images=(base)
+sdk_only_images=(sdk-23 sdk-25 sdk-27)
+ndk_images=(sdk-23-ndk sdk-25-ndk sdk-27-ndk)
 
-# Build the base images first.
+# Build the base image first.
 for i in "${base_images[@]}"
 do
   cd "$CURRENT_DIR""$DIRECTORY_SEPARATOR""$i"
   docker build -t dubit/android-build-image:"$i" .
 done
 
-# Build the NDK based images second since those are
-# based on the base ones.
+# Build the sdk only images next.
+for i in "${sdk_only_images[@]}"
+do
+  cd "$CURRENT_DIR""$DIRECTORY_SEPARATOR""$i"
+  docker build -t dubit/android-build-image:"$i" .
+done
+
+# Build the NDK based images last since those are
+# based on the sdk ones.
 for n in "${ndk_images[@]}"
 do
   cd "$CURRENT_DIR""$DIRECTORY_SEPARATOR""$n"

--- a/android-build/sdk-23-ndk/Dockerfile
+++ b/android-build/sdk-23-ndk/Dockerfile
@@ -1,5 +1,8 @@
 FROM dubit/android-build-image:sdk-23
 
+# --- Switch to the root user to install the NDK and it's components
+USER root
+
 ENV ANDROID_NDK_HOME /opt/android-ndk
 ENV ANDROID_NDK_VERSION r10e
 
@@ -12,6 +15,8 @@ RUN rm -rf /opt/android-ndk-tmp
 
 # --- Update the PATH variable ---
 ENV PATH ${PATH}:${ANDROID_NDK_HOME}
+
+USER builder
 
 VOLUME /usr/src/app
 WORKDIR /usr/src/app

--- a/android-build/sdk-23/Dockerfile
+++ b/android-build/sdk-23/Dockerfile
@@ -1,42 +1,7 @@
 FROM ubuntu:16.04
 
-# --- Environment variables ---
-ENV ANDROID_HOME /opt/android-sdk-linux
-
-# --- Run system tool updates ---
-RUN apt-get update
-RUN apt-get -y install unzip
-RUN apt-get -y install curl
-RUN apt-get -y install git
-RUN apt-get -y install python
-RUN apt-get -y install build-essential
-
-# --- Install Android build requirements ---
-RUN dpkg --add-architecture i386
-RUN apt-get update -qq
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386
-
-# --- Create the Android repository config file ---
-# * This is not required, but makes warnings on installing packages go away.
-RUN mkdir /root/.android
-RUN touch /root/.android/repositories.cfg
-
-# --- Download the Android SDK tools and export to $ANDROID_HOME ---
-ENV ANDROID_HOME /opt/android-sdk-linux
-RUN cd /opt \
-    && curl https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -o android-sdk-tools.zip \
-    && unzip -q android-sdk-tools.zip -d ${ANDROID_HOME} \
-    && rm -f android-sdk-tools.zip
-
-# --- Update the PATH variable ---
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
-
 # --- Install the required build packages, tools and SDKs ---
 # * To get a list of available packages run: sdkmanager --list
-
-# --- Accept all standard component licenses before installing any component. ---
-# * Non-standard components: MIPS system images, preview versions, GDK (Google Glass) and Android Google TV require separate licenses, not accepted there
-RUN yes | sdkmanager --licenses
 
 # --- Update the android SDK repositories ---
 RUN sdkmanager "platform-tools"
@@ -47,6 +12,8 @@ RUN sdkmanager "platforms;android-23"
 
 # --- Install build-tools
 # * If you are installing multiple build tool packages keep these in descending order!
+RUN sdkmanager "build-tools;23.0.3"
+RUN sdkmanager "build-tools;23.0.2"
 RUN sdkmanager "build-tools;23.0.1"
 
 # --- Install Extras
@@ -57,44 +24,6 @@ RUN sdkmanager "extras;google;google_play_services"
 # --- Install Google APIs
 # * If you are installing multiple API packages keep these in descending order!
 RUN sdkmanager "add-ons;addon-google_apis-google-23"
-
-# --- Install Gradle ---
-RUN apt-get -y install gradle
-RUN gradle -v
-
-# --- Install Maven 3 ---
-# * Purge any installations of Maven 1 & 2 including user configurations
-RUN apt-get purge maven maven2
-RUN apt-get update
-RUN apt-get -y install maven
-RUN mvn --version
-
-# --- Install Ruby required for Fastlane operations ---
-RUN apt-get -y install ruby-full
-RUN ruby -v
-
-# --- Install Bundler as the primary package manager for Ruby ---
-RUN gem install bundler
-RUN bundler version
-
-# --- Install NodeJS required for react native projects
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
-RUN apt-get -y install nodejs
-
-# --- Install Yarn as an alternative to NPM for package management ---
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install yarn
-RUN yarn --version
-
-# --- Install React-Native's CLI ---
-RUN npm install -g react-native-cli
-
-# --- Install Microsoft's CodePush service ---
-RUN npm install -g code-push-cli
-
-# --- Cleanup ---
-RUN apt-get clean
 
 RUN useradd -ms /bin/bash builder
 USER builder

--- a/android-build/sdk-23/Dockerfile
+++ b/android-build/sdk-23/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM dubit/android-build-image:base
 
 # --- Install the required build packages, tools and SDKs ---
 # * To get a list of available packages run: sdkmanager --list

--- a/android-build/sdk-25-ndk/Dockerfile
+++ b/android-build/sdk-25-ndk/Dockerfile
@@ -1,5 +1,8 @@
 FROM dubit/android-build-image:sdk-25
 
+# --- Switch to the root user to install the NDK and it's components
+USER root
+
 ENV ANDROID_NDK_HOME /opt/android-ndk
 ENV ANDROID_NDK_VERSION r10e
 
@@ -12,6 +15,8 @@ RUN rm -rf /opt/android-ndk-tmp
 
 # --- Update the PATH variable ---
 ENV PATH ${PATH}:${ANDROID_NDK_HOME}
+
+USER builder
 
 VOLUME /usr/src/app
 WORKDIR /usr/src/app

--- a/android-build/sdk-25/Dockerfile
+++ b/android-build/sdk-25/Dockerfile
@@ -1,42 +1,7 @@
-FROM ubuntu:16.04
-
-# --- Environment variables ---
-ENV ANDROID_HOME /opt/android-sdk-linux
-
-# --- Run system tool updates ---
-RUN apt-get update
-RUN apt-get -y install unzip
-RUN apt-get -y install curl
-RUN apt-get -y install git
-RUN apt-get -y install python
-RUN apt-get -y install build-essential
-
-# --- Install Android build requirements ---
-RUN dpkg --add-architecture i386
-RUN apt-get update -qq
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk libc6:i386 libstdc++6:i386 libgcc1:i386 libncurses5:i386 libz1:i386
-
-# --- Create the Android repository config file ---
-# * This is not required, but makes warnings on installing packages go away.
-RUN mkdir /root/.android
-RUN touch /root/.android/repositories.cfg
-
-# --- Download the Android SDK tools and export to $ANDROID_HOME ---
-ENV ANDROID_HOME /opt/android-sdk-linux
-RUN cd /opt \
-    && curl https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -o android-sdk-tools.zip \
-    && unzip -q android-sdk-tools.zip -d ${ANDROID_HOME} \
-    && rm -f android-sdk-tools.zip
-
-# --- Update the PATH variable ---
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+FROM dubit/android-build-image:base
 
 # --- Install the required build packages, tools and SDKs ---
 # * To get a list of available packages run: sdkmanager --list
-
-# --- Accept all standard component licenses before installing any component. ---
-# * Non-standard components: MIPS system images, preview versions, GDK (Google Glass) and Android Google TV require separate licenses, not accepted there
-RUN yes | sdkmanager --licenses
 
 # --- Update the android SDK repositories ---
 RUN sdkmanager "platform-tools"
@@ -52,6 +17,8 @@ RUN sdkmanager "platforms;android-23"
 RUN sdkmanager "build-tools;25.0.3"
 RUN sdkmanager "build-tools;25.0.2"
 RUN sdkmanager "build-tools;24.0.3"
+RUN sdkmanager "build-tools;23.0.3"
+RUN sdkmanager "build-tools;23.0.2"
 RUN sdkmanager "build-tools;23.0.1"
 
 # --- Install Extras
@@ -62,44 +29,6 @@ RUN sdkmanager "extras;google;google_play_services"
 # --- Install Google APIs
 # * If you are installing multiple API packages keep these in descending order!
 RUN sdkmanager "add-ons;addon-google_apis-google-23"
-
-# --- Install Gradle ---
-RUN apt-get -y install gradle
-RUN gradle -v
-
-# --- Install Maven 3 ---
-# * Purge any installations of Maven 1 & 2 including user configurations
-RUN apt-get purge maven maven2
-RUN apt-get update
-RUN apt-get -y install maven
-RUN mvn --version
-
-# --- Install Ruby required for Fastlane operations ---
-RUN apt-get -y install ruby-full
-RUN ruby -v
-
-# --- Install Bundler as the primary package manager for Ruby ---
-RUN gem install bundler
-RUN bundler version
-
-# --- Install NodeJS required for react native projects
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
-RUN apt-get -y install nodejs
-
-# --- Install Yarn as an alternative to NPM for package management ---
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install yarn
-RUN yarn --version
-
-# --- Install React-Native's CLI ---
-RUN npm install -g react-native-cli
-
-# --- Install Microsoft's CodePush service ---
-RUN npm install -g code-push-cli
-
-# --- Cleanup ---
-RUN apt-get clean
 
 RUN useradd -ms /bin/bash builder
 USER builder

--- a/android-build/sdk-27-ndk/Dockerfile
+++ b/android-build/sdk-27-ndk/Dockerfile
@@ -1,0 +1,24 @@
+FROM dubit/android-build-image:sdk-27
+
+# --- Switch to the root user to install the NDK and it's components
+USER root
+
+ENV ANDROID_NDK_HOME /opt/android-ndk
+ENV ANDROID_NDK_VERSION r10e
+
+# -- Download the Android NDK and export to $ANDROID_NDK ---
+RUN mkdir /opt/android-ndk-tmp
+RUN cd /opt/android-ndk-tmp && curl https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip -o android-ndk.zip
+RUN cd /opt/android-ndk-tmp && unzip android-ndk.zip
+RUN cd /opt/android-ndk-tmp && mv ./android-ndk-r10e /opt/android-ndk
+RUN rm -rf /opt/android-ndk-tmp
+
+# --- Update the PATH variable ---
+ENV PATH ${PATH}:${ANDROID_NDK_HOME}
+
+USER builder
+
+VOLUME /usr/src/app
+WORKDIR /usr/src/app
+
+CMD ls

--- a/android-build/sdk-27/Dockerfile
+++ b/android-build/sdk-27/Dockerfile
@@ -1,0 +1,48 @@
+FROM dubit/android-build-image:base
+
+# --- Install the required build packages, tools and SDKs ---
+# * To get a list of available packages run: sdkmanager --list
+
+# --- Update the android SDK repositories ---
+RUN sdkmanager "platform-tools"
+
+# --- Install android SDK
+# * If you are installing multiple SDK packages keep these in descending order!
+RUN sdkmanager "platforms;android-27"
+RUN sdkmanager "platforms;android-26"
+RUN sdkmanager "platforms;android-25"
+RUN sdkmanager "platforms;android-24"
+RUN sdkmanager "platforms;android-23"
+
+# --- Install build-tools
+# * If you are installing multiple build tool packages keep these in descending order!
+RUN sdkmanager "build-tools;27.0.3"
+RUN sdkmanager "build-tools;27.0.2"
+RUN sdkmanager "build-tools;27.0.1"
+RUN sdkmanager "build-tools;27.0.0"
+RUN sdkmanager "build-tools;26.0.2"
+RUN sdkmanager "build-tools;26.0.1"
+RUN sdkmanager "build-tools;25.0.3"
+RUN sdkmanager "build-tools;25.0.2"
+RUN sdkmanager "build-tools;24.0.3"
+RUN sdkmanager "build-tools;23.0.3"
+RUN sdkmanager "build-tools;23.0.2"
+RUN sdkmanager "build-tools;23.0.1"
+
+# --- Install Extras
+RUN sdkmanager "extras;android;m2repository"
+RUN sdkmanager "extras;google;m2repository"
+RUN sdkmanager "extras;google;google_play_services"
+
+# --- Install Google APIs
+# * If you are installing multiple API packages keep these in descending order!
+RUN sdkmanager "add-ons;addon-google_apis-google-23"
+
+RUN useradd -ms /bin/bash builder
+USER builder
+RUN mkdir ~/.gradle && touch ~/.gradle/gradle.properties
+
+VOLUME /usr/src/app
+WORKDIR /usr/src/app
+
+CMD ls


### PR DESCRIPTION
I have made a couple of structural changes in this PR.

There is now a new target called `:base`. This target is used for the common layer between all other targets. There was a lot of duplication across our Dockerfiles for different SDKs for no good reason. Build times were also getting a lot longer. This should help that.

I have also added a target for SDK-27 as most of the in house projects are now targeting that version of the SDK. It also has a corresponding target for an NDK bundle.