### PR TITLE
Add android sdk 29 and 30. Update Ubuntu to 18.04. Update node to 12.x.

### DIFF
--- a/android-build/README.md
+++ b/android-build/README.md
@@ -19,10 +19,10 @@ All build images extend the `:base` build image. It contains all common utilitie
   * GCC (included by build-essential)
   * python 2.7
   * openJDK-8
-  * Node.js 11.x
-  * Ruby 2.3
+  * Node.js 12.x
+  * Ruby 2.5.1
 * SDKs:
-  * Android SDK 23/25/27/28
+  * Android SDK 29/30
   * Android NDK r10e
   * Android build-tools - _all versions of build tools corresponding to the SDK version are included_
 

--- a/android-build/base/Dockerfile
+++ b/android-build/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # --- Environment variables ---
 ENV ANDROID_HOME /opt/android-sdk-linux
@@ -26,9 +26,11 @@ RUN ruby -v
 
 # --- Install Bundler as the primary package manager for Ruby ---
 RUN gem install bundler
+# --- Install Rubygems 3.1.4 for compatibility with Bundler 2 ---
+RUN gem update --system 3.1.4
 
 # --- Install NodeJS required for react native projects
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get -y install nodejs
 
 # --- Install Yarn as an alternative to NPM for package management ---

--- a/android-build/sdk-30/Dockerfile
+++ b/android-build/sdk-30/Dockerfile
@@ -1,0 +1,38 @@
+FROM dubit/android-build-image:base
+
+# --- Install the required build packages, tools and SDKs ---
+# * To get a list of available packages run: sdkmanager --list
+
+# --- Update the android SDK repositories ---
+RUN sdkmanager "platform-tools"
+
+# --- Install android SDK
+# * If you are installing multiple SDK packages keep these in descending order!
+RUN sdkmanager "platforms;android-30"
+RUN sdkmanager "platforms;android-29"
+
+# --- Install build-tools
+# * If you are installing multiple build tool packages keep these in descending order!
+RUN sdkmanager "build-tools;30.0.3"
+RUN sdkmanager "build-tools;29.0.3"
+
+# --- Install Extras
+RUN sdkmanager "extras;android;m2repository"
+RUN sdkmanager "extras;google;m2repository"
+RUN sdkmanager "extras;google;google_play_services"
+
+# --- Install Google APIs
+# * If you are installing multiple API packages keep these in descending order!
+RUN sdkmanager "add-ons;addon-google_apis-google-23"
+
+RUN useradd -ms /bin/bash builder
+USER builder
+RUN mkdir ~/.gradle && touch ~/.gradle/gradle.properties
+
+# Set GEM_HOME so that all aspects of gem installations are local to the user we just created to avoid permission issues
+ENV GEM_HOME=~/.gem
+
+VOLUME /usr/src/app
+WORKDIR /usr/src/app
+
+CMD ls


### PR DESCRIPTION
This PR updates some components of the android-build images to:
* Update node to 12
* Add support for android sdks 29 and 30, removing the older ones which are no longer supported by the Google play store and are bloating the image size
* Update Ubuntu to 18.04